### PR TITLE
Fix typo in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,5 +5,5 @@
   "license": "MIT",
   "require": {
     "php": ">=5.4"
-  },
+  }
 }


### PR DESCRIPTION
Noticed a trailing comma when trying to execute composer install. 
