### PR TITLE
Add support for Windows opening SQL files in HeidiSQL (if it is available)

### DIFF
--- a/Commands/PancakesCommand.php
+++ b/Commands/PancakesCommand.php
@@ -68,8 +68,12 @@ class PancakesCommand extends TerminusCommand {
 
       foreach ($possible_heidi_locations as $phl) {
         if (file_exists($phl)) {
-
-          $command = sprintf('start /b "" "%s" -h="%s" -P=%s -u="%s" -p="%s"', $phl, $mysql_host, $mysql_port, $mysql_username, $mysql_password);
+          $phl = escapeshellarg($phl);
+          $mysql_host = escapeshellarg($mysql_host);
+          $mysql_port = escapeshellarg($mysql_port);
+          $mysql_username = escapeshellarg($mysql_username);
+          $mysql_password = escapeshellarg($mysql_password);
+          $command = sprintf('start /b "" %s -h=%s -P=%s -u=%s -p=%s', $phl, $mysql_host, $mysql_port, $mysql_username, $mysql_password);
           exec($command);
           break;
         } else {

--- a/Commands/PancakesCommand.php
+++ b/Commands/PancakesCommand.php
@@ -63,6 +63,7 @@ class PancakesCommand extends TerminusCommand {
       $possible_heidi_locations = array(
         'C:\Program Files\HeidiSQL\heidisql.exe',
         'C:\Program Files (x86)\HeidiSQL\heidisql.exe',
+        getenv('TERMINUS_PANCAKES_HEIDISQL_LOC'),
       );
 
       foreach ($possible_heidi_locations as $phl) {

--- a/Commands/PancakesCommand.php
+++ b/Commands/PancakesCommand.php
@@ -69,7 +69,6 @@ class PancakesCommand extends TerminusCommand {
         if (file_exists($phl)) {
 
           $command = sprintf('start /b "" "%s" -h="%s" -P=%s -u="%s" -p="%s"', $phl, $mysql_host, $mysql_port, $mysql_username, $mysql_password);
-          $this->log()->info($command);
           exec($command);
           break;
         } else {

--- a/Commands/PancakesCommand.php
+++ b/Commands/PancakesCommand.php
@@ -54,23 +54,44 @@ class PancakesCommand extends TerminusCommand {
     $mysql_port = $connection_info['mysql_port'];
     $mysql_database = $connection_info['mysql_database'];
 
-    $this->log()->info('Opening {site} in SequelPro', array('site' => $site->get('name')));
-
-    $label = sprintf('%s [%s]', $site->get('name'), $env_id);
-    $openxml = $this->getOpenFile($label, $mysql_host, $mysql_port, $mysql_username, $mysql_password, $mysql_database);
-
-    $tempfile = tempnam('/tmp', 'terminus-sequelpro') . '.spf';
-
-    $handle = fopen($tempfile, "w");
-    fwrite($handle, $openxml);
-    fclose($handle);
-
     // Wake the Site
     $environment->wake();
 
-    // Open in SequelPro
-    $command = sprintf('%s %s', 'open', $tempfile);
-    exec($command);
+    if (\Terminus\Utils\isWindows()) {
+      $this->log()->info('Opening {site} in HeidiSQL', array('site' => $site->get('name')));
+
+      $possible_heidi_locations = array(
+        'C:\Program Files\HeidiSQL\heidisql.exe',
+        'C:\Program Files (x86)\HeidiSQL\heidisql.exe',
+      );
+
+      foreach ($possible_heidi_locations as $phl) {
+        if (file_exists($phl)) {
+
+          $command = sprintf('start /b "" "%s" -h="%s" -P=%s -u="%s" -p="%s"', $phl, $mysql_host, $mysql_port, $mysql_username, $mysql_password);
+          $this->log()->info($command);
+          exec($command);
+          break;
+        } else {
+          continue;
+        }
+      }
+    } else {
+      $this->log()->info('Opening {site} in SequelPro', array('site' => $site->get('name')));
+
+      $label = sprintf('%s [%s]', $site->get('name'), $env_id);
+      $openxml = $this->getOpenFile($label, $mysql_host, $mysql_port, $mysql_username, $mysql_password, $mysql_database);
+
+      $tempfile = tempnam('/tmp', 'terminus-sequelpro') . '.spf';
+
+      $handle = fopen($tempfile, "w");
+      fwrite($handle, $openxml);
+      fclose($handle);
+
+      // Open in SequelPro
+      $command = sprintf('%s %s', 'open', $tempfile);
+      exec($command);
+    }
   }
 
   /**

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pancakes
 
-Terminus Plugin to open Pantheon Databases in SequelPro
+Terminus Plugin to open Pantheon Databases in [Sequel Pro](http://www.sequelpro.com/) (Mac) or [HeidiSQL](http://www.heidisql.com/) (Windows).
 
-Adds a sub-command to 'site' which is called 'pancakes'. This opens a site in Sequel Pro
+Adds a sub-command to 'site' which is called 'pancakes'. This opens a site in the appropriate database management application.
 
 ## Examples
 * `terminus site pancakes`
@@ -10,6 +10,9 @@ Adds a sub-command to 'site' which is called 'pancakes'. This opens a site in Se
 
 ## Installation
 For help installing, see [Terminus's Wiki](https://github.com/pantheon-systems/terminus/wiki/Plugins)
+
+## A Note About Windows
+The plugin will automatically attempt to find the HeidiSQL executable within your `Program Files` directory.  If your version of HeidiSQL is installed in a non-standard location or you are using the portable version of HeidiSQL, ensure the full path to heidisql.exe (including the executable itself) is set in the `TERMINUS_PANCAKES_HEIDISQL_LOC` environment variable.
 
 ## Help
 Run `terminus help site pancakes` for help.


### PR DESCRIPTION
This adds support for opening MySQL connections to Pantheon via HeidiSQL and Terminus.  @derimagia -- can you confirm I didn't break Mac with this change?

The only negative about this is that it doesn't release the user's terminal back for more input until after HeidiSQL has been closed.  I tried a couple things to get around this but didn't seem to have much luck.
