### PR TITLE
Add MySQL App

### DIFF
--- a/src/Apps/MySQLApp.php
+++ b/src/Apps/MySQLApp.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pantheon\TerminusPancakes\Apps;
+
+/**
+ * Open Site database in MySQL CLI
+ */
+class MySQLApp extends PancakesApp {
+  /**
+   * {@inheritdoc}
+   */
+  public $aliases = ['mysql'];
+
+  /**
+   * {@inheritdoc}
+   */
+  public $app = 'MySQL';
+
+  /**
+   * - App Location Candinates
+   */
+  public $app_location;
+
+  public function open(){
+    $cmd = join(' ', [
+      'mysql',
+      '-h ' . $this->escapeShellArg($this->connection_info['mysql_host']),
+      '-P ' . $this->escapeShellArg($this->connection_info['mysql_port']),
+      '-u ' . $this->escapeShellArg($this->connection_info['mysql_username']),
+      '-p' . $this->escapeShellArg($this->connection_info['mysql_password']),
+      $this->connection_info['mysql_database'],
+    ]);
+
+    $process = proc_open(
+      $cmd,
+      [
+        0 => STDIN,
+        1 => STDOUT,
+        2 => STDERR,
+      ],
+      $pipes
+    );
+    proc_close($process);
+  }
+
+  /**
+   * Validates the app can be used
+   */
+  public function validate() {
+    if ($this->isWindows()) {
+      return FALSE;
+    }
+
+    $this->app_location = 'mysql';
+    return $this->which($this->app_location);
+  }
+}


### PR DESCRIPTION
This PR proposes a new `--app` for invoking the `mysql` CLI. 

Example: `terminus pc site.env --app mysql`. 

I'm not enthusiastic about using `proc_open`, but I wasn't sure what a good alternative would be for having Terminus handoff control to another cli process.

Thank you in advance for feedback!