### PR TITLE
Updated version to accept 1.9 and 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "extra": {
     "terminus": {
-      "compatible-version": "^1"
+      "compatible-version": "^1.9|^2"
     }
   }
 }


### PR DESCRIPTION
Per Greg Anderson's work on the other Pantheon System maintained plugins.  
This change to composer should allow the plugin to operate as expected with Terminus, 1.9, 2.0 and higher