### PR TITLE
Terminus 3.0 compatibility

### DIFF
--- a/src/Commands/PancakesCommand.php
+++ b/src/Commands/PancakesCommand.php
@@ -10,8 +10,6 @@ use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\TerminusPancakes\Apps\PancakesApp;
 
-include __DIR__ . DIRECTORY_SEPARATOR . '../..' . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
-
 /**
  * Open Site database in your favorite MySQL Editor
  *


### PR DESCRIPTION
When the plugin is installed with the terminus 3 command (`terminus self:plugin:install terminus-plugin-project/terminus-pancakes-plugin `), every subsequent terminus command generates multiple PHP warnings:
```
PHP Warning:  include(/Users/jmann/.terminus/terminus-dependencies-2512c16/vendor/terminus-plugin-project/terminus-pancakes-plugin/src/Commands/../../vendor/autoload.php): failed to open stream: No such file or directory in /Users/jmann/.terminus/terminus-dependencies-2512c16/vendor/terminus-plugin-project/terminus-pancakes-plugin/src/Commands/PancakesCommand.php on line 13
```

The plugin still works as expected without this include statement, so I propose simply removing it.