### PR TITLE
Fix pantheon site URL output in logs

### DIFF
--- a/src/Commands/PancakesCommand.php
+++ b/src/Commands/PancakesCommand.php
@@ -116,7 +116,7 @@ class PancakesCommand extends TerminusCommand Implements SiteAwareInterface {
 
     $this->log()
       ->notice('Opening {site} database in {app}.', [
-        'site' => $env->id . '-' . $site->get('name') . '.pantheon.io',
+        'site' => $env->id . '-' . $site->get('name') . '.pantheonsite.io',
         'app' => $instance->app
       ]);
 


### PR DESCRIPTION
This PR is a simple fix to logging output.

Currently, the site environment hostname output to console is incorrect. See example below:

```
$ terminus pc ucf-sdes.dev
[notice] Multiple Pancakes Applications were found: Sequel Pro, SequelAce, MySQL. Add --app to be specific on the app.
[notice] Opening dev-ucf-sdes.pantheon.io database in Sequel Pro.
$
```

The host should be: `dev-ucf-sdes.pantheon.io`. It's missing the string "site" in the output.

I also noticed around line 50 in PancakesCommand.php the same string `.pantheon.io` is used when creating some IDs, but but those IDs probably don't need to change(?) so I left it.